### PR TITLE
Binary ↔ ASCII converter: allow spaces between octets

### DIFF
--- a/binary-ascii/eff.js
+++ b/binary-ascii/eff.js
@@ -4,9 +4,9 @@
 	    ascii = textareas[0],
 	    binary = textareas[1],
 	    permalink = document.getElementById('permalink'),
-	    regexBinaryGroup = /[01]{8}/g,
+	    regexBinaryGroup = /\s*[01]{8}\s*/g,
 	    regexAnyCharacter = /[\s\S]/g,
-	    regexBinary = /^([01]{8})*$/,
+	    regexBinary = /^(\s*[01]{8}\s*)*$/,
 	    regexExtendedASCII = /^[\x00-\xff]*$/,
 	    // http://mathiasbynens.be/notes/localstorage-pattern
 	    storage = (function() {


### PR DESCRIPTION
Because it is customary to separate the groups of 8 bits by spaces, allow
the input to have spaces, too. Because `parseInt('    01100001  ', 2)` is
the same as `parseInt('01100001', 2)`, this has no effect on the outcome.

Example input: http://pastebin.com/NKbnh8q8

(Sorry about the autogenerated `patch-1` branch name. GitHub made me do it!)
