### PR TITLE
Added option to disable \x shorthand

### DIFF
--- a/js-escapes/eff.js
+++ b/js-escapes/eff.js
@@ -5,7 +5,7 @@
 	var textarea = document.getElementsByTagName('textarea')[0];
 	var inputs = document.getElementsByTagName('input');
 	var checkboxOnlyASCII = inputs[0];
-	var checkboxUseShorthand = inputs[1];
+	var checkboxOutputJSON = inputs[1];
 	var checkboxES6 = inputs[2];
 	var checkboxStringBody = inputs[3];
 	var permalink = document.getElementById('permalink');
@@ -75,8 +75,8 @@
 				'quotes': 'single',
 				'wrap': true,
 				'escapeEverything': !checkboxOnlyASCII.checked,
-				'json' : checkboxUseShorthand.checked,
-				'es6': checkboxES6.checked
+				'json' : checkboxOutputJSON.checked,
+				'es6': checkboxES6.checked && !checkboxOutputJSON.checked
 			});
 			text(
 				code,
@@ -93,10 +93,10 @@
 			} else {
 				storage.removeItem('jsEscapeOnlyASCII');
 			}
-			if (!checkboxUseShorthand.checked) {
-				storage.jsEscapeNotShorthand = true;
+			if (checkboxOutputJSON.checked) {
+				storage.jsEscapeOutputJSON = true;
 			} else {
-				storage.removeItem('jsEscapeNotShorthand');
+				storage.removeItem('jsEscapeOutputJSON');
 			}
 			if (checkboxStringBody.checked) {
 				storage.jsEscapeStringBody = true;
@@ -104,11 +104,12 @@
 				storage.removeItem('jsEscapeStringBody');
 			}
 		}
+		checkboxES6.disabled = checkboxOutputJSON.checked;
 		permalink.hash = +checkboxOnlyASCII.checked + encode(textarea.value);
 	}
 
 	// https://mathiasbynens.be/notes/oninput
-	textarea.onkeyup = checkboxOnlyASCII.onchange = checkboxUseShorthand.onchange = checkboxES6.onchange = checkboxStringBody.onchange = update;
+	textarea.onkeyup = checkboxOnlyASCII.onchange = checkboxOutputJSON.onchange = checkboxES6.onchange = checkboxStringBody.onchange = update;
 	textarea.oninput = function() {
 		textarea.onkeyup = null;
 		update();
@@ -125,7 +126,7 @@
 	if (storage) {
 		storage.jsEscapeText && (textarea.value = storage.jsEscapeText);
 		storage.jsEscapeOnlyASCII && (checkboxOnlyASCII.checked = true);
-		storage.jsEscapeNotShorthand && (checkboxUseShorthand.checked = false);
+		storage.jsEscapeOutputJSON && (checkboxOutputJSON.checked = true);
 		storage.jsEscapeStringBody && (checkboxStringBody.checked = true);
 		update();
 	}

--- a/js-escapes/eff.js
+++ b/js-escapes/eff.js
@@ -5,8 +5,9 @@
 	var textarea = document.getElementsByTagName('textarea')[0];
 	var inputs = document.getElementsByTagName('input');
 	var checkboxOnlyASCII = inputs[0];
-	var checkboxES6 = inputs[1];
-	var checkboxStringBody = inputs[2];
+	var checkboxUseShorthand = inputs[1];
+	var checkboxES6 = inputs[2];
+	var checkboxStringBody = inputs[3];
 	var permalink = document.getElementById('permalink');
 	// https://mathiasbynens.be/notes/localstorage-pattern
 	var storage = (function() {
@@ -74,6 +75,7 @@
 				'quotes': 'single',
 				'wrap': true,
 				'escapeEverything': !checkboxOnlyASCII.checked,
+				'json' : checkboxUseShorthand.checked,
 				'es6': checkboxES6.checked
 			});
 			text(
@@ -91,6 +93,11 @@
 			} else {
 				storage.removeItem('jsEscapeOnlyASCII');
 			}
+			if (!checkboxUseShorthand.checked) {
+				storage.jsEscapeNotShorthand = true;
+			} else {
+				storage.removeItem('jsEscapeNotShorthand');
+			}
 			if (checkboxStringBody.checked) {
 				storage.jsEscapeStringBody = true;
 			} else {
@@ -101,7 +108,7 @@
 	}
 
 	// https://mathiasbynens.be/notes/oninput
-	textarea.onkeyup = checkboxOnlyASCII.onchange = checkboxES6.onchange = checkboxStringBody.onchange = update;
+	textarea.onkeyup = checkboxOnlyASCII.onchange = checkboxUseShorthand.onchange = checkboxES6.onchange = checkboxStringBody.onchange = update;
 	textarea.oninput = function() {
 		textarea.onkeyup = null;
 		update();
@@ -118,6 +125,7 @@
 	if (storage) {
 		storage.jsEscapeText && (textarea.value = storage.jsEscapeText);
 		storage.jsEscapeOnlyASCII && (checkboxOnlyASCII.checked = true);
+		storage.jsEscapeNotShorthand && (checkboxUseShorthand.checked = false);
 		storage.jsEscapeStringBody && (checkboxStringBody.checked = true);
 		update();
 	}

--- a/js-escapes/index.html
+++ b/js-escapes/index.html
@@ -9,7 +9,7 @@
 <noscript><strong>To use this tool, please <a href=http://enable-javascript.com/>enable JavaScript</a> and reload the page.</strong></noscript>
 <textarea autofocus>Fingerspitzengefühl is a German term.\nIt’s pronounced as follows: [ˈfɪŋɐˌʃpɪtsənɡəˌfyːl]</textarea>
 <div><label><input type=checkbox checked> only escape non-ASCII and unprintable ASCII characters</label></div>
-<div><label><input type=checkbox checked> use shorthand characters (\xB0 instead of \u00B0)</label></div>
+<div><label><input type=checkbox> output JSON</label></div>
 <div><label><input type=checkbox> use ES6 Unicode code point escapes for astral symbols</label></div>
 <div><label><input type=checkbox checked> treat as JavaScript string body</label></div>
 <p><a href=#1Fingerspitzengef%C3%BChl%20is%20a%20German%20term.%5CnIt%E2%80%99s%20pronounced%20as%20follows%3A%20%5B%CB%88f%C9%AA%C5%8B%C9%90%CB%8C%CA%83p%C9%AAts%C9%99n%C9%A1%C9%99%CB%8Cfy%CB%90l%5D id=permalink>permalink</a>

--- a/js-escapes/index.html
+++ b/js-escapes/index.html
@@ -9,6 +9,7 @@
 <noscript><strong>To use this tool, please <a href=http://enable-javascript.com/>enable JavaScript</a> and reload the page.</strong></noscript>
 <textarea autofocus>Fingerspitzengefühl is a German term.\nIt’s pronounced as follows: [ˈfɪŋɐˌʃpɪtsənɡəˌfyːl]</textarea>
 <div><label><input type=checkbox checked> only escape non-ASCII and unprintable ASCII characters</label></div>
+<div><label><input type=checkbox checked> use shorthand characters (\xB0 instead of \u00B0)</label></div>
 <div><label><input type=checkbox> use ES6 Unicode code point escapes for astral symbols</label></div>
 <div><label><input type=checkbox checked> treat as JavaScript string body</label></div>
 <p><a href=#1Fingerspitzengef%C3%BChl%20is%20a%20German%20term.%5CnIt%E2%80%99s%20pronounced%20as%20follows%3A%20%5B%CB%88f%C9%AA%C5%8B%C9%90%CB%8C%CA%83p%C9%AAts%C9%99n%C9%A1%C9%99%CB%8Cfy%CB%90l%5D id=permalink>permalink</a>


### PR DESCRIPTION
For using output in Java, .properties files, or other places where the
\xHHHH syntax cannot be used.