### PR TITLE
add clear button, make named entities the default

### DIFF
--- a/html-entities/index.html
+++ b/html-entities/index.html
@@ -9,7 +9,7 @@
 <noscript><strong>To use this tool, please <a href=http://enable-javascript.com/>enable JavaScript</a> and reload the page.</strong></noscript>
 <h2>Decoded:</h2>
 <textarea id="decoded" autofocus>Foo © bar 𝌆 baz ☃ qux</textarea>
-<input type="reset" value="Clear" style="float:right;" onclick="document.getElementById('decoded').value=''; document.getElementById('encoded').value='';">
+<button style="float:right;" onclick="document.getElementById('decoded').value=''; document.getElementById('encoded').value='';">Clear</button>
 <h2>Encoded: (<a href=#Foo%20%C2%A9%20bar%20%F0%9D%8C%86%20baz%20%E2%98%83%20qux id=permalink>permalink</a>)</h2>
 <textarea id="encoded">Foo &amp;#xA9; bar &amp;#x1D306; baz &amp;#x2603; qux</textarea>
 <div><label><input type=checkbox checked> only encode unsafe and non-ASCII characters</label></div>

--- a/html-entities/index.html
+++ b/html-entities/index.html
@@ -9,9 +9,9 @@
 <noscript><strong>To use this tool, please <a href=http://enable-javascript.com/>enable JavaScript</a> and reload the page.</strong></noscript>
 <h2>Decoded:</h2>
 <textarea id="decoded" autofocus>Foo © bar 𝌆 baz ☃ qux</textarea>
-<input type="reset" value="Clear" style="float:right;" onclick="document.getElementById('decoded').value = ''">
+<input type="reset" value="Clear" style="float:right;" onclick="document.getElementById('decoded').value=''; document.getElementById('encoded').value='';">
 <h2>Encoded: (<a href=#Foo%20%C2%A9%20bar%20%F0%9D%8C%86%20baz%20%E2%98%83%20qux id=permalink>permalink</a>)</h2>
-<textarea>Foo &amp;#xA9; bar &amp;#x1D306; baz &amp;#x2603; qux</textarea>
+<textarea id="encoded">Foo &amp;#xA9; bar &amp;#x1D306; baz &amp;#x2603; qux</textarea>
 <div><label><input type=checkbox checked> only encode unsafe and non-ASCII characters</label></div>
 <div><label><input type=checkbox checked> allow named character references in output (incompatible with older browsers)</label></div>
 <h2>About this tool</h2>

--- a/html-entities/index.html
+++ b/html-entities/index.html
@@ -8,11 +8,12 @@
 <h1>HTML entity encoder/decoder</h1>
 <noscript><strong>To use this tool, please <a href=http://enable-javascript.com/>enable JavaScript</a> and reload the page.</strong></noscript>
 <h2>Decoded:</h2>
-<textarea autofocus>Foo © bar 𝌆 baz ☃ qux</textarea>
+<textarea id="decoded" autofocus>Foo © bar 𝌆 baz ☃ qux</textarea>
+<input type="reset" value="Clear" style="float:right;" onclick="document.getElementById('decoded').value = ''">
 <h2>Encoded: (<a href=#Foo%20%C2%A9%20bar%20%F0%9D%8C%86%20baz%20%E2%98%83%20qux id=permalink>permalink</a>)</h2>
 <textarea>Foo &amp;#xA9; bar &amp;#x1D306; baz &amp;#x2603; qux</textarea>
 <div><label><input type=checkbox checked> only encode unsafe and non-ASCII characters</label></div>
-<div><label><input type=checkbox> allow named character references in output (incompatible with older browsers)</label></div>
+<div><label><input type=checkbox checked> allow named character references in output (incompatible with older browsers)</label></div>
 <h2>About this tool</h2>
 <p>This tool uses <a href=https://mths.be/he><i>he</i></a> to HTML-encode any string you enter in the ‘decoded’ field, or to decode any HTML-encoded string you enter in the ‘encoded’ field.
 <p id=footer>Made by <a href=https://mathiasbynens.be/>@mathias</a> — <a href=https://github.com/mathiasbynens/mothereff.in/tree/master/html-entities>fork this on GitHub!</a></p>


### PR DESCRIPTION
Having a "Clear" button for the input field makes life so much easier when copying text between tabs. I also made named entities the default as they are much easier to read and supported by all curent browsers.